### PR TITLE
Revert "Fixed #24013 -- Fixed escaping of reverse() prefix."

### DIFF
--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -194,24 +194,17 @@ class URLPatternReverse(TestCase):
                reverse('non_path_include', prefix='/{{invalid}}/'))
 
     def test_prefix_parenthesis(self):
-        # Parentheses are allowed and should not cause errors or be escaped
-        self.assertEqual(
-            '/bogus)/includes/non_path_include/',
-            reverse('non_path_include', prefix='/bogus)/')
-        )
-        self.assertEqual(
-            '/(bogus)/includes/non_path_include/',
-            reverse('non_path_include', prefix='/(bogus)/')
-        )
+        self.assertEqual('/bogus%29/includes/non_path_include/',
+               reverse('non_path_include', prefix='/bogus)/'))
 
     def test_prefix_format_char(self):
         self.assertEqual('/bump%2520map/includes/non_path_include/',
                reverse('non_path_include', prefix='/bump%20map/'))
 
     def test_non_urlsafe_prefix_with_args(self):
-        # Regression for #20022, adjusted for #24013 because ~ is an unreserved
-        # character. Tests whether % is escaped.
-        self.assertEqual('/%257Eme/places/1/', reverse('places', args=[1], prefix='/%7Eme/'))
+        # Regression for #20022
+        self.assertEqual('/%7Eme/places/1/',
+                reverse('places', args=[1], prefix='/~me/'))
 
     def test_patterns_reported(self):
         # Regression for #17076
@@ -225,12 +218,6 @@ class URLPatternReverse(TestCase):
             # we can't use .assertRaises, since we want to inspect the
             # exception
             self.fail("Expected a NoReverseMatch, but none occurred.")
-
-    def test_script_name_escaping(self):
-        self.assertEqual(
-            reverse('optional', args=['foo:bar'], prefix='/script:name/'),
-            '/script:name/optional/foo:bar/'
-        )
 
 
 class ResolverTests(unittest.TestCase):


### PR DESCRIPTION
This reverts commit 39ba9afa4ae7a7f26ba7b8d4bd4eb8deb9b14629.

BB relies on the old (broken?) behavior.